### PR TITLE
font size & padding/margin fix (#106) + header on scroll bug fix (#110)

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -82,6 +82,14 @@ h4 {
     }
 }
 
+p {
+    font-size: 16px;
+    margin-top: 0;
+    @media (min-width: 640px)  {
+        font-size: 18px;
+    }
+}
+
 a {
     cursor: pointer;
 }
@@ -130,4 +138,15 @@ ul, ol {
     flex-direction: row;
     justify-content: center;
     align-items: center;
+}
+
+/* Targets all elements that have an id attribute */
+[id] { /* e.g documention anchors */
+    scroll-margin-top: 7rem;
+    margin-bottom: 0.75rem;
+
+    @media (min-width: 640px) {
+        scroll-margin-top: 8rem; 
+    }
+
 }

--- a/src/.vuepress/theme/enhanceApp.js
+++ b/src/.vuepress/theme/enhanceApp.js
@@ -5,10 +5,27 @@
  */
 
 export default ({
-  Vue, // the version of Vue being used in the VuePress app
-  options, // the options for the root Vue instance
-  router, // the router instance for the app
-  siteData, // site metadata
+  Vue, 
+  options, 
+  router, 
+  siteData, 
 }) => {
-  // ...apply enhancements for the site.
+  router.options.scrollBehavior = async (to, from, savedPosition) => {
+    if (to.hash){
+      const elem = document.querySelector(to.hash)
+      // vue-router does not incorporate scroll-margin-top on its own.
+      if (elem) {
+        const offset = parseFloat(getComputedStyle(elem).scrollMarginTop)
+        return {
+          selector: to.hash,
+          offset: { y: offset }
+        }
+      }
+
+      if (savedPosition) return savedPosition
+      return { x: 0, y: 0 }
+    } else {
+        return { x: 0, y: 0 }
+    }
+  }
 };


### PR DESCRIPTION
Made some css adjustments for issue #106.

For bug #110:
a) added an enhanceApp.js file in 'layouts' folder, as suggested in vuepress docs (https://v1.vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements) in order to fix the scrolling after the click on sidebar titles (links). The bug is related on how the vue-router handles the routing (https://github.com/gridsome/gridsome/issues/1361).
b) added some lines of css to solve the direct click on titles (on hashtags).

Now it should work everything correctly!