### PR TITLE
Features page: fix typo

### DIFF
--- a/src/features.md
+++ b/src/features.md
@@ -122,7 +122,7 @@ Stratum V1's 2012 pooled mining extension predates ASIC mining farms. Considerin
 
 ## Multiplexing
 
-Allows a single connection (e.g. TCP) for independent communication channels between any number of devices, reducing the total connections anh costs necessary for pools and proxies.
+Allows a single connection (e.g. TCP) for independent communication channels between any number of devices, reducing the total connections and costs necessary for pools and proxies.
 
 #### Technical Description
 


### PR DESCRIPTION
Just a teeny typo [on the Features page](https://stratumprotocol.org/features/#multiplexing). Though I'm not sure how I got here because I don't see a link to the Features page on the top navigation bar of https://stratumprotocol.org. Must have been from a blog post.