### PR TITLE
moved past supporters tab to be inline with others #212

### DIFF
--- a/src/.vuepress/theme/layouts/Home.vue
+++ b/src/.vuepress/theme/layouts/Home.vue
@@ -173,13 +173,7 @@
 
         <!-- Supporters category selection -->
         <Tabs
-          :tabs="data.supportersTabs"
-          :selected="selectedSupportersTab"
-          @tab-selected="selectedSupportersTab = $event"
-        />
-
-        <Tabs
-          :tabs="data.pastSupportersTabs"
+          :tabs="combinedSupportersTabs"
           :selected="selectedSupportersTab"
           @tab-selected="selectedSupportersTab = $event"
         />
@@ -292,6 +286,7 @@ export default {
 
   computed: {
     data() {
+      console.log(this.$page.frontmatter)
       return this.$page.frontmatter;
     },
     displayedSupporters() {
@@ -300,6 +295,18 @@ export default {
       return this.data.supporters.filter(({ value }) =>
         this.selectedSupportersTab.supporters.includes(value)
       );
+    },
+    combinedSupportersTabs() {
+      const combinedTabs = [
+        ...this.data.supportersTabs,
+        ...this.data.pastSupportersTabs.map(tab => {
+          return {
+            ...tab,
+            name: tab.name
+          };
+        })
+      ];
+      return combinedTabs;
     },
   },
 


### PR DESCRIPTION
Moved the **Past Supporters** tab to be inline with other tabs

![Screen Shot 2024-05-05 at 2 31 46 PM](https://github.com/stratum-mining/stratumprotocol.org/assets/34426399/b47d4a9b-b017-4c8c-b4c7-44ccb5c88859)

This will create an issue for the layout on mobile as the row will exceed the viewWidth -- this can be resolved by adding a media query for display widths under 440px, then changing the font-size to the text-links to 0.85rem -- will create a separate issue and PR for this.
