### PR TITLE
Add GCC to Prerequisites

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -15,6 +15,13 @@ Rust installed on your machine. If it's not:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
+
+GCC installed on your machine.
+```bash
+sudo yum install gcc #or similar
+```
+
+
 There are two primary ways to use all roles:  
 
 - Run certain roles and connecting to our community-hosted roles. (The easiest way to test SRI)


### PR DESCRIPTION
While setting up an amazon linux ec2 instance I noticed that GCC needs to be installed to compile/run from code.