### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       # Checkout and setup
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
       - name: Setup
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       # Install and build

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,21 @@
+name: Update submodule
+
+on:
+  repository_dispatch:
+    types:
+      - update-submodule
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          submodules: recursive
+      - name: Update module
+        run: |
+          git submodule update --init --recursive --checkout -f --remote -- "${{github.event.client_payload.module}}"
+          git config --global user.name "GitHub Action"
+          git config --global user.email "noreply@github.com"
+          git commit -am "deploy: ${{github.event.client_payload.module}} - ${{github.event.client_payload.sha}}"
+          git push


### PR DESCRIPTION
Updates the CI action modules and adds a new action to fix #224. In addition to this, the spec repo needs this GitHub Action added as `.github/workflows/dispatch-update.yml`:

```yaml
name: Dispatch update
on:
  - push
  - workflow_dispatch
jobs:
  dispatch:
    runs-on: ubuntu-latest
    steps:
      - name: Push to repo
        uses: peter-evans/repository-dispatch@v3
        with:
          token: ${{ secrets.PAT }}
          repository: stratum-mining/stratumprotocol.org
          event-type: update-submodule
          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "module": "src/specification", "branch": "main"}'
 ```
 
 Both repositories will need to get defined a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `repo` scope as `PAT` in the repositories secrets.