### PR TITLE
Updates the TP version on `src/getting-started.md` to 0.1.15

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -85,10 +85,10 @@ rpcuser=username
 rpcpassword=password
 ```
 
-Unpack the Template Provider. For example, assuming you downloaded `bitcoin-sv2-tp-0.1.12-x86_64-linux-gnu.tar.gz`:
+Unpack the Template Provider. For example, assuming you downloaded `bitcoin-sv2-tp-0.1.15-x86_64-linux-gnu.tar.gz`:
 
 ```bash
-tar xvf bitcoin-sv2-tp-0.1.12-x86_64-linux-gnu.tar.gz
+tar xvf bitcoin-sv2-tp-0.1.15-x86_64-linux-gnu.tar.gz
 ```
 
 ⚠️ Note: macOS binaries are not code signed. Read release notes for instructions on how to proceed.
@@ -96,7 +96,7 @@ tar xvf bitcoin-sv2-tp-0.1.12-x86_64-linux-gnu.tar.gz
 Start the Template Provider.
 
 ```bash
-./bitcoin-sv2-tp-0.1.12/bin/bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 
+./bitcoin-sv2-tp-0.1.15/bin/bitcoind -testnet4 -sv2 -sv2port=8442 -debug=sv2 
 ```
 
 ⚠️ Note: you need to wait until `bitcoind` is fully synced with the testnet before you proceed.
@@ -111,7 +111,7 @@ There are optional parameters which can be used to better manage the Template Pr
 For example: 
 
 ```bash
-./bitcoin-sv2-tp-0.1.12/bin/bitcoind -testnet4 -sv2 -sv2port=8442 -sv2interval=20 -sv2feedelta=1000 -debug=sv2 -loglevel=sv2:trace
+./bitcoin-sv2-tp-0.1.15/bin/bitcoind -testnet4 -sv2 -sv2port=8442 -sv2interval=20 -sv2feedelta=1000 -debug=sv2 -loglevel=sv2:trace
 ```
 This way new templates are constructed every 20 seconds (taking the most profitable txs from the mempool) and they are sent downstream if new fees collected are more than 1000 sats. 
 


### PR DESCRIPTION
This PR updates all occurrences of the TP version on the website from **0.1.12** to **0.1.15**, as suggested in [PR #1456: Add `coinbase_output_max_additional_sigops` to SRI](https://github.com/stratum-mining/stratum/pull/1456).  
