### PR TITLE
Add instructions to checkout the latest stable release 

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -33,7 +33,22 @@ There are two primary ways to use all roles:
 
 ```bash
 git clone https://github.com/stratum-mining/stratum.git
+cd stratum
 ```
+
+#### Checkout the latest stable release
+
+```bash
+git tag --sort=version:refname | tail -1 | xargs git checkout
+```
+
+Alternatively, you can list all available tags and checkout a specific one:
+
+```bash
+git tag --sort=version:refname
+git checkout v1.3.0  # Replace with the latest version shown
+```
+
 #### Run Job Declarator Client (JDC)
 ```bash
 cd roles/jd-client/config-examples/
@@ -119,7 +134,22 @@ This way new templates are constructed every 20 seconds (taking the most profita
 
 ```bash
 git clone https://github.com/stratum-mining/stratum.git
+cd stratum
 ```
+
+#### Checkout the latest stable release
+
+```bash
+git tag --sort=version:refname | tail -1 | xargs git checkout
+```
+
+Alternatively, you can list all available tags and checkout a specific one:
+
+```bash
+git tag --sort=version:refname
+git checkout v1.3.0  # Replace with the latest version shown
+```
+
 #### Run the SV2 Pool
 
 ```bash


### PR DESCRIPTION
Our current `getting-started` guide simply tells the user to clone our repo, without saying to checkout a stable release branch.

Since `main` is always under development, it could contain bugs, and we should guide the user to checkout a stable release before running SRI.

This PR adds those instructions to that.