### PR TITLE
Update checkout command in `getting-started.md` to fix 'detached HEAD' state

### DIFF
--- a/app/src/_blog/getting-started.md
+++ b/app/src/_blog/getting-started.md
@@ -40,7 +40,7 @@ cd stratum
 #### Checkout the latest stable release
 
 ```bash
-git tag --sort=version:refname | tail -1 | xargs git checkout
+git fetch origin && git checkout -b $(git tag --sort=version:refname | tail -1)
 ```
 
 Alternatively, you can list all available tags and checkout a specific one:


### PR DESCRIPTION
This PR fixes the command to checkout the latest release branch.

The command which was leading to a detached HEAD state has been introduced by PR https://github.com/stratum-mining/stratumprotocol.org/pull/249, my bad.

