### PR TITLE
Fix mobile navigation "Get Started" link

### DIFF
--- a/app/src/components/Navigation.tsx
+++ b/app/src/components/Navigation.tsx
@@ -203,7 +203,7 @@ export function Navigation() {
                   onClick={() => setIsMenuOpen(false)}
                   aria-label={t("navigation.getStarted")}
                 >
-                  <NavLink to="/wizard">
+                  <NavLink to="/get-started">
                     {t("navigation.getStarted")}
                   </NavLink>
                 </Button>


### PR DESCRIPTION
The mobile menu was linking to /wizard which returns 404. Updated to /get-started to match the desktop navigation.

Minor fix for merged PR #291.