### PR TITLE
use `sv2-wizard` v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^3.0.1",
     "remark-slug": "^7.0.1",
-    "sv2-wizard": "^0.1.1",
+    "sv2-wizard": "^0.1.2",
     "tailwind-merge": "^3.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5975,10 +5975,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-sv2-wizard@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/sv2-wizard/-/sv2-wizard-0.1.1.tgz#7471aad2aace5740318fa8d78de7bc344560f29f"
-  integrity sha512-4eTGOtB3ME3xAvtM9bD5G7v5vlmEuZt9MQK5BseAal4sZGB2P0z+gurkDPkmK/DpqBfahdiOjlsg3Kotux72cA==
+sv2-wizard@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/sv2-wizard/-/sv2-wizard-0.1.2.tgz#de59033d3d412418a23dc5eeaea39007a27b7ac5"
+  integrity sha512-EiR47HrALeY7ynEBGkvT32mlDnWf9Jwhk/01rt0dzbAyuUdzugMMO+mwyqxgEREpPxNcp1TBQJwGpY2GrWhoCw==
   dependencies:
     "@radix-ui/react-label" "^2.1.8"
     "@radix-ui/react-select" "^2.2.6"


### PR DESCRIPTION
This PR updates the wizard on our website to make it use the newest version v0.1.2.

Blocked by https://github.com/stratum-mining/sv2-wizard/pull/9.