### PR TITLE
Fix start mining anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         <div class="hero-content">
           <h1><span data-i18n="hero.title.prefix">Open ₿itcoin</span> <span class="cyan" data-i18n="hero.title.highlight">mining</span> <span data-i18n="hero.title.suffix">standard</span></h1>
           <p data-i18n="hero.subtitle">Stratum V2 is a mining protocol that makes mining operations more efficient, profitable, secure, private and decentralized.</p>
-          <a href="#start-mining-image" class="cta-button" id="start-mining-btn">
+          <a href="#start-mining-steps" class="cta-button" id="start-mining-btn">
             <span data-i18n="hero.cta">Start Mining</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M5 12h14"></path>
@@ -968,7 +968,7 @@
           />
         </figure>
 
-        <div class="start-mining-flow">
+        <div class="start-mining-flow" id="start-mining-steps">
 
           <!-- OS Selector -->
           <div class="os-selector" role="group" aria-label="Select operating system" data-i18n-aria-label="startMining.os.select">

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="navbar-actions">
-      <a href="/#start-mining-image" class="start-mining-nav" aria-label="Start mining" data-i18n-aria-label="nav.startMining">
+      <a href="/#start-mining-steps" class="start-mining-nav" aria-label="Start mining" data-i18n-aria-label="nav.startMining">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M14.531 12.469 6.619 20.38a1 1 0 1 1-3-3l7.912-7.912"></path>
           <path d="M15.686 4.314A12.5 12.5 0 0 0 5.461 2.958 1 1 0 0 0 5.58 4.71a22 22 0 0 1 6.318 3.393"></path>

--- a/styles.css
+++ b/styles.css
@@ -2832,6 +2832,7 @@ html:not(.dark) .start-mining-preview img.start-mining-img-light {
   background: transparent;
   padding: 0;
   box-shadow: none;
+  scroll-margin-top: calc(var(--header-offset) + 1.5rem);
 }
 
 .start-mining-command-wrap {


### PR DESCRIPTION
When start mining is clicked, this PR makes sure it's anchored to actual steps and not the image, which on some device size pushes commands below the fold.