### PR TITLE
Add CK Pool to the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1459,6 +1459,15 @@
                   <span class="adopter-desc" data-i18n="adopter.braiinspool.desc">In production pool</span>
                 </div>
               </a>
+              <a class="adopter-item" href="https://solo.ckpool.org" target="_blank" rel="noopener">
+                <div class="adopter-logo" aria-hidden="true">
+                  <span class="ckpool-logo">CK</span>
+                </div>
+                <div class="adopter-info">
+                  <span class="adopter-name">CKPool</span>
+                  <span class="adopter-desc" data-i18n="adopter.ckpool.desc">In production solo pool</span>
+                </div>
+              </a>
               <a class="adopter-item" href="https://www.dmnd.work/" target="_blank" rel="noopener">
                 <div class="adopter-logo">
                   <img src="/assets/logos/demand-logo.svg" alt="DMND" width="612" height="258" loading="lazy" decoding="async" />

--- a/locales/ar.txt
+++ b/locales/ar.txt
@@ -216,6 +216,7 @@ adopter.nerdaxe.desc = دعم أصلي لبرنامج Stratum V2 الثابت
 adopter.bitaxe.desc = دعم أصلي لبرنامج Stratum V2 الثابت
 adopter.braiinspool.desc = مجمّع يعمل في الإنتاج
 adopter.blitzpool.desc = مجمّع منفرد يعمل في الإنتاج
+adopter.ckpool.desc = مجمّع منفرد يعمل في الإنتاج
 adopter.sripool.desc = تعدين منفرد وجماعي مع قوالب مخصصة، للاختبار فقط
 adopter.dmnd.desc = مجمّع يعمل في الإنتاج مع تمكين قوالب يختارها المعدّنون
 adopter.mkpool.desc = مجمّع منفرد يعمل في الإنتاج

--- a/locales/en.txt
+++ b/locales/en.txt
@@ -217,6 +217,7 @@ adopter.nerdaxe.desc = Native Stratum V2 firmware support
 adopter.bitaxe.desc = Native Stratum V2 firmware support
 adopter.braiinspool.desc = In production pool
 adopter.blitzpool.desc = In production solo pool
+adopter.ckpool.desc = In production solo pool
 adopter.sripool.desc = Solo & pool mining with custom templates, testing only
 adopter.dmnd.desc = In production pool, enabling miner selected templates
 adopter.mkpool.desc = In production solo pool

--- a/locales/es.txt
+++ b/locales/es.txt
@@ -216,6 +216,7 @@ adopter.nerdaxe.desc = Soporte nativo de firmware Stratum V2
 adopter.bitaxe.desc = Soporte nativo de firmware Stratum V2
 adopter.braiinspool.desc = Pool en producción
 adopter.blitzpool.desc = Pool solo en producción
+adopter.ckpool.desc = Pool solo en producción
 adopter.sripool.desc = Minería en solitario y en grupo con plantillas personalizadas, solo para pruebas
 adopter.dmnd.desc = Pool en producción con plantillas seleccionadas por mineros
 adopter.mkpool.desc = Pool solo en producción

--- a/locales/it.txt
+++ b/locales/it.txt
@@ -217,6 +217,7 @@ adopter.nerdaxe.desc = Supporto firmware nativo Stratum V2
 adopter.bitaxe.desc = Supporto firmware nativo Stratum V2
 adopter.braiinspool.desc = Pool in produzione
 adopter.blitzpool.desc = Solo pool in produzione
+adopter.ckpool.desc = Solo pool in produzione
 adopter.sripool.desc = Mining in solo e in pool con template personalizzati, solo per test
 adopter.dmnd.desc = Pool in produzione, abilita i template selezionati dai miner
 adopter.mkpool.desc = Solo pool in produzione

--- a/locales/ru.txt
+++ b/locales/ru.txt
@@ -216,6 +216,7 @@ adopter.nerdaxe.desc = Нативная поддержка Stratum V2 в про�
 adopter.bitaxe.desc = Нативная поддержка Stratum V2 в прошивке
 adopter.braiinspool.desc = Пул в продакшене
 adopter.blitzpool.desc = Соло-пул в продакшене
+adopter.ckpool.desc = Соло-пул в продакшене
 adopter.sripool.desc = Сольный и пуловый майнинг с пользовательскими шаблонами, только для тестирования
 adopter.dmnd.desc = Пул в продакшене с поддержкой шаблонов, выбираемых майнерами
 adopter.mkpool.desc = Соло-пул в продакшене

--- a/locales/zh.txt
+++ b/locales/zh.txt
@@ -216,6 +216,7 @@ adopter.nerdaxe.desc = 原生 Stratum V2 固件支持
 adopter.bitaxe.desc = 原生 Stratum V2 固件支持
 adopter.braiinspool.desc = 生产环境矿池
 adopter.blitzpool.desc = 生产环境单人矿池
+adopter.ckpool.desc = 生产环境单人矿池
 adopter.sripool.desc = 支持独立与矿池挖矿及自定义模板，仅限测试
 adopter.dmnd.desc = 生产环境矿池，支持矿工选择模板
 adopter.mkpool.desc = 生产环境单人矿池

--- a/styles.css
+++ b/styles.css
@@ -4319,6 +4319,18 @@ a.adopter-item {
   padding: 0.375rem;
 }
 
+.adopter-logo .ckpool-logo {
+  color: #000;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.025em;
+}
+
+.dark .adopter-logo .ckpool-logo {
+  color: #fff;
+}
+
 /* Invert logos for light mode */
 :root:not(.dark) .adopter-logo img {
   filter: invert(1) hue-rotate(180deg);


### PR DESCRIPTION
Soon enough we'll have to figure out a new way to present new adopters, great problems to have. This PR adds the most well known solo pool out there as SV2 adopter. [Context](https://x.com/ckpooldev/status/2078782323437510853)

The only issue here is that when we point people to the CK website, they won't have a way to get endpoints there. I hope that will eventually be solved, yet SV2 is experimental and endpoints are currently kept pin on CK's profile. Users of SV2 won't have these issues  https://github.com/stratum-mining/sv2-ui/pull/220 as it's already hardcoded for them.

<img width="1098" height="848" alt="Screenshot 2026-07-20 at 20 38 09" src="https://github.com/user-attachments/assets/b5feee69-dee4-457e-b381-e8bf0ad85b51" />
<img width="1059" height="834" alt="Screenshot 2026-07-20 at 20 38 16" src="https://github.com/user-attachments/assets/e25955ea-7250-409d-8615-2c70b51244e1" />
